### PR TITLE
fix for nulls in vim script

### DIFF
--- a/autoload/xolox/session.vim
+++ b/autoload/xolox/session.vim
@@ -152,6 +152,9 @@ function! xolox#session#save_qflist(commands) " {{{2
         endif
         unlet qf_entry.bufnr
       endif
+      if has_key(qf_entry, 'text')
+        let qf_entry.text = substitute(qf_entry.text, "\n", " ", "g")
+      endif
       call add(qf_list, qf_entry)
     endfor
     call add(a:commands, 'call setqflist(' . string(qf_list) . ')')


### PR DESCRIPTION
there is a bug where newlines in quickfix list get translated into null characters when put in a variable, and then written as ^@ in the session scripts, which makes the script invalid.
related to https://vim.fandom.com/wiki/Newlines_and_nulls_in_Vim_script